### PR TITLE
Expert edit form

### DIFF
--- a/app/controllers/experts_controller.rb
+++ b/app/controllers/experts_controller.rb
@@ -1,6 +1,7 @@
 class ExpertsController < ApplicationController
   def edit
     @expert = Expert.find(params[:id])
+    @field = Field.new
   end
 
   def update

--- a/app/controllers/experts_controller.rb
+++ b/app/controllers/experts_controller.rb
@@ -1,0 +1,23 @@
+class ExpertsController < ApplicationController
+  def edit
+    @expert = Expert.find(params[:id])
+  end
+
+  def update
+    @expert = Expert.find(params[:id])
+    if @expert.update_attributes(edit_params)
+      flash[:notice] = "Operação realizada com sucesso"
+      redirect_to @expert
+    else
+      flash[:alert] = @expert.errors.message.join('<br>')
+      render 'edit'
+    end
+  end
+
+  private
+
+  def edit_params
+    params.require(:expert).permit(:phone_number, :city, :distance, :curriculum, :accept)
+  end
+  
+end

--- a/app/views/experts/_form.html.erb
+++ b/app/views/experts/_form.html.erb
@@ -1,0 +1,19 @@
+<%= simple_form_for @expert do |f| %>
+  <%= f.input :doc_number, label: 'CPF ou CNPJ', placeholder: 'CPF ou CNPJ',
+      disabled: true %>
+  <%= f.input :phone_number, label: 'Telefone de contato', placeholder: 'Telefone para contato',
+      disabled: !current_page?(edit_expert_path) %>
+  <%= f.input :city, label: 'Endereço', placeholder: 'Endereço',
+      disabled: !current_page?(edit_expert_path) %>
+  <%= f.input :distance, label: 'Raio de atuação (km)', placeholder: '100',
+      input_html: { value: 100, min: 0, max: 500, step: 10 },
+      disabled: !current_page?(edit_expert_path) %>
+  <%= f.input :curriculum, label: 'Currículo Lattes', placeholder: 'http://lattes.cnpq.br/123',
+      disabled: !current_page?(edit_expert_path) %>
+  <%= f.input :accept, label: false, placeholder: 'Escolha uma opção',
+      collection: { 'Justiça Gratuita' => 0, 'Perícia Particular' => 1,'Ambos' => 2 },
+      disabled: !current_page?(edit_expert_path) %>
+  <%= f.button :button, class: 'btn btn-primary' do %>
+    <i class="far fa-save"></i> Atualizar
+  <% end if current_page?(edit_expert_path) %>
+<% end %>

--- a/app/views/experts/edit.html.erb
+++ b/app/views/experts/edit.html.erb
@@ -1,3 +1,37 @@
 <h1>Seu perfil</h1>
 <h3><%= current_user.full_name %></h3>
 <%= render 'form' %>
+<h2>Suas especialidades</h2>
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th scope="col">Área</th>
+      <th scope="col">Especialidade</th>
+      <th scope="col">Registro Conselho</th>
+      <th scope="col"><i class="fas fa-sliders-h"></i></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @expert.fields.each do |field| %>
+      <tr>
+        <th><%= field.area %></th>
+        <td><%= field.title %></td>
+        <td><%= field.reg_number %></td>
+        <td><i class="far fa-edit"></i> <i class="far fa-trash-alt"></i></td>
+      </tr>
+    <% end %>
+  
+    <tr>
+      <%= simple_form_for [@expert, @field] do |f| %>
+        <th><%= f.input :area, label:false  %></th>
+        <td><%= f.input :title, label:false %></td>
+        <td><%= f.input :reg_number, label:false %></td>
+        <td>
+          <%= f.button :button, class: 'btn btn-primary' do %>
+            <i class="fas fa-plus"></i>
+          <% end %>
+        </td>
+      <% end %>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/experts/edit.html.erb
+++ b/app/views/experts/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Seu perfil</h1>
+<h3><%= current_user.full_name %></h3>
+<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
-  resources :experts, only: %i[edit update]
+  resources :experts, only: %i[edit update] do
+    resources :fields, only: :create
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
+  resources :experts, only: %i[edit update]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/experts_controller_test.rb
+++ b/test/controllers/experts_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ExpertsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Criado formulário para edição de cadastro de auxiliar.
Campo CPF é bloqueado para edição.
O formulário é uma partial que pode ser usada para outros propósitos. Quando usado em outras páginas, os campos ficam bloqueados para edição e o botão submit é suprimido